### PR TITLE
lots of text and css changes

### DIFF
--- a/nar_common/static/nar_ui/common.less
+++ b/nar_common/static/nar_ui/common.less
@@ -165,7 +165,7 @@ header.row{background:#000;
 }
  
 .menu-item {display:none;
-  width: 360px; 
+  width: 380px; 
   text-align:left;
   box-shadow:0 1px 5px rgba(0,0,0,.3);
  
@@ -190,7 +190,6 @@ header.row{background:#000;
   color: rgb(0,51,102) !important;
   display: block;
   text-decoration: none;
-  width: 360px;
   font-family:"Source Sans Pro";
   
 }

--- a/nar_common/static/nar_ui/nar.less
+++ b/nar_common/static/nar_ui/nar.less
@@ -251,9 +251,16 @@ ul.toc-indentation li ul li{font-size:.85em;}
  					border:1px solid rgb(174,174,174);
  					margin-right:10px;}
  					
- .home_icon_holder h4{padding-top:5px;
- 					font-size:1.1em;}
- 
+ .home_icon_holder h4{
+	 font-size:1.1em;
+	 margin-bottom:-15px;
+	 line-height:1.4em;}
+	 
+ .home_icon_holder em{
+	 font-size:.9em;
+	 font-style:normal;
+	 font-weight:normal;}
+	 
  .last{margin-right:0;}
  
  .inside{background:#fff;
@@ -377,6 +384,8 @@ tr.clickableRow:hover{color:rgb(0,102,153);}
                  
 .statement i{-webkit-transform:rotate(270deg);
 			-moz-transform:rotate(270deg);
+			-ms-transform:rotate(270deg);
+			transform:rotate(270deg);
 			color:rgb(7,7,251);
 }
         
@@ -910,7 +919,7 @@ select.last{margin-right:0;}
  						height:42px;
  						border-radius:5px;
  						margin-top:20px;
- 						font-size:1.7em;
+ 						font-size:1em;
  						font-family:@baseFontFamily;
  						outline:none;}
  						
@@ -1556,8 +1565,10 @@ ul#relativeLinks{
 	 					height:310px;
 	 					margin-right:10px;}
 	 					
-	 .home_icon_holder h4{font-size:.9em;}
-	 
+	 .home_icon_holder h4{
+		 font-size:.9em;
+		 }
+		 
 	 .inside{width:270px;
 	 		height:238px;}
 	 
@@ -1683,15 +1694,21 @@ ul#relativeLinks{
 	 			font-size:1em;
 	 }
 	 
-	.center{width:725px;
+	.center{
+		width:725px;
+		margin-left:13px;
 	}
 	 
 	 .home_icon_holder{width:235px;
 	 					height:260px;
 	 					margin-right:10px;}
 	 					
-	 .home_icon_holder h4{font-size:1.2em;
-	 }
+	 .home_icon_holder h4{
+		 font-size:.9em;
+		 }
+
+	.home_icon_holder h4.last-h4{
+	margin-bottom:10px;}
 	 
 	 
 	 .inside{
@@ -1896,7 +1913,17 @@ ul#relativeLinks{
 	 					margin-right:10px;
 	 					}
 	 					
-	 .home_icon_holder h4{font-size:1.2em;}
+	 .home_icon_holder h4{
+		 font-size:.9em;
+		 }
+		 
+	.home_icon_holder h4.first-h4{
+	padding-top:5px;
+	margin-bottom:-3px;}
+	
+	.home_icon_holder h4.last-h4{
+	margin-bottom:10px;}
+	 
 	 
 	 
 	 .inside{width:200px;

--- a/nar_common/templates/base.html
+++ b/nar_common/templates/base.html
@@ -32,7 +32,8 @@
 <link href="{% static 'nar_ui/ie_fix.css' %} rel="stylesheet" type="text/css">
 		<div id="block">
 <h1>We apologize, but this site does not support Internet Explorer versions lower than 9.0</h1>
-<p>If using IE 10 or 11 please make sure Compatibility View is turned off.</p>
+<p>If using IE 10 or 11 please make sure Compatibility View is turned off by clicking on ‘Tools’ 
+from the top menu bar, selecting ‘Compatibility view settings’, uncheck boxes, and click ‘Close’.</p>
 <p>Other supported browsers are Firefox, Chrome, and Safari.</p>
 </div>
 	<![endif]-->
@@ -152,16 +153,16 @@
         	<li class="small">Data
             
             	 <div class="menu-item">
-      <h4><a href="{% url 'site' %}">Streams and Rivers Across the United States</a></h4>
+      <h4><a href="{% url 'site' %}">Streams and Rivers Across the United States - Water Quality Summaries</a></h4>
       
     </div>                      
                      <div class="menu-item">
-      <h4><a href="{% url 'mississippi' %}">Mississippi River Basin</a></h4>
+      <h4><a href="{% url 'mississippi' %}">Mississippi River Basin Summary - Relative Nutrient Loading from Tributaries</a></h4>
       
     </div>
     
     <div class="menu-item">
-      <h4><a href="{% url 'coastal' %}">Nitrate in Coastal Rivers</a></h4>
+      <h4><a href="{% url 'coastal' %}">Coastal Rivers - Nitrate Loads and Yields</a></h4>
      
     </div>
     
@@ -181,11 +182,7 @@
       <div class="menu-item">
       <h4><a href="{% url 'fixed_site_network' %}">Objectives</a></h4>
     </div>
-    
-    <div class="menu-item">
-      <h4><a href="{% url 'network_site_list' %}">Network Site List</a></h4>
-    </div>
-       
+           
     <div class="menu-item">
       <h4><a href="{% url 'technical_information' %}">Technical Information and Glossary</a></h4>
     </div>
@@ -215,7 +212,7 @@
 
 <div class="row show">
 	
-	<div id="show_hide">Hide Header/Footer</div>
+	<div id="show_hide">Toggle Header/Footer</div>
 
 </div>
 

--- a/nar_common/templates/nar_ui/coastal.html
+++ b/nar_common/templates/nar_ui/coastal.html
@@ -9,7 +9,7 @@
 	
 	<div class="col-lg-12 col-md-12 col-sm-12 col-xs-12 coastal_title">
 	
-		<h3>Nitrate Loads and Yields in Coastal Rivers</h3>
+		<h3>Coastal Rivers - Nitrate Loads and Yields</h3>
 					
 		<a href="{% url 'download' %}"><button id="coastalDownload" class="additional">Download Data</button></a>
 	
@@ -25,17 +25,17 @@
 		
 			<div id="coastal_info">
 			
-				<p>Hover over (or click) on a <i class="glyphicon glyphicon-play"></i> for site information</p>
+				<p>Select (or click) on a Region for load and yield graphs</p>
 			
 			</div>
 			
-			<a class="link_coastal_region" data-region="ne_inset" href="{% url 'coastal_region' %}?region=northeast"><button>Northeast</button></a>
+			<a class="link_coastal_region" data-region="ne_inset" href="{% url 'coastal_region' %}?region=northeast"><button>North and Middle Atlantic</button></a>
 			
-			<a class="link_coastal_region" data-region="se_inset" href="{% url 'coastal_region' %}?region=southeast"><button>Southeast</button></a>
+			<a class="link_coastal_region" data-region="se_inset" href="{% url 'coastal_region' %}?region=southeast"><button>South Atlantic</button></a>
 			
-			<a class="link_coastal_region" data-region="gulf_inset" href="{% url 'coastal_region' %}?region=gulf"><button>Gulf</button></a>
+			<a class="link_coastal_region" data-region="gulf_inset" href="{% url 'coastal_region' %}?region=gulf"><button>Gulf of Mexico</button></a>
 			
-			<a class="link_coastal_region" data-region="west_inset,westAKonly_inset" href="{% url 'coastal_region' %}?region=west"><button>West</button></a>
+			<a class="link_coastal_region" data-region="west_inset,westAKonly_inset" href="{% url 'coastal_region' %}?region=west"><button>Pacific</button></a>
 			
 			<ul>
 			

--- a/nar_common/templates/nar_ui/home.html
+++ b/nar_common/templates/nar_ui/home.html
@@ -24,7 +24,7 @@
 	<a href="{% url 'site' %}">
 		<div class="col-lg-3 col-md-3 col-sm-3 col-xs-3 home_icon_holder">
 
-			<h4>Streams and Rivers Across the United States </h4>
+			<h4 class="first-h4">Streams and Rivers Across the United States <br><em>Water Quality Summaries</em> </h4>
 			
 			<div class="inside">
 			
@@ -39,7 +39,7 @@
 	<a href="{% url 'mississippi' %}">
 	<div class="col-lg-3 col-md-3 col-sm-3 col-xs-3 home_icon_holder">
 	
-		<h4>Mississippi River Basin</h4>
+		<h4>Mississippi River Basin Summary <br><em>Relative Nutrient Loading from Tributaries</em></h4>
 		
 		<div class="inside">
 		
@@ -53,7 +53,7 @@
 	<a href="{% url 'coastal' %}">
 	<div class="col-lg-3 col-md-3 col-sm-3 col-xs-3 home_icon_holder last">
 	
-		<h4>Nitrate in Coastal Rivers</h4>
+		<h4 class="last-h4">Coastal Rivers <br> <em>Nitrate Loads and Yields</em></h4>
 		
 		<div class="inside">
 		

--- a/nar_common/templates/nar_ui/mississippi.html
+++ b/nar_common/templates/nar_ui/mississippi.html
@@ -11,7 +11,7 @@
 <div class=" row mississippi_holder">
 	<div class="col-lg-12 col-md-12 col-sm-12 col-xs-12 mississippi_title">
 	
-		<h3>Nutrient Loads in the Mississippi-Atchafalaya River Basin</h3>
+		<h3>Mississippi River Basin Summary - Relative Nutrient Loading from Tributaries</h3>
 		
 		<h6>The width of each river shows its relative contribution to nutrient loading 
 		
@@ -28,8 +28,6 @@
 		</h6>
 
 		<a href="{% url 'help' %}"><button id="help">Help?</button></a>
-		
-		<a href="{% url 'download' %}"><button id="download">Download Data</button></a>
 		
 		<button id="toggle" >Toggle Sites <i class="glyphicon glyphicon-play"></i></button>
 

--- a/nar_common/templates/nar_ui/site.html
+++ b/nar_common/templates/nar_ui/site.html
@@ -56,7 +56,7 @@ $(document).on("click", ".check_filter", function (event) {
 
 		<div class="col-lg-12 col-md-12 col-sm-12 col-xs-12 site_title">
 		
-			<h3>Streams and Rivers Across the United States</h3>
+			<h3>Streams and Rivers Across the United States - Water Quality Summaries</h3>
 		
 		</div>
    


### PR DESCRIPTION
General
1. added material to the lead page to improve this such as. Add this to the ‘error note’ that pops-up: Ensure compatibility view is turned off by clicking on ‘Tools’ from the top menu bar, selecting ‘Compatibility view settings’, uncheck boxes, and click ‘Close’.

2. Revised text for each on the (1) home page buttons, (2) navigation menu, and (3) report page template titles. 
          Summaries for Stream and River Sites Across the United States
          Mississippi River Basin Summary – Relative Nutrient Loading from Tributaries
          Coastal Rivers Summary – Nitrate Loads and Yields

3. ‘Hide Header/Footer’ changed to ‘Toggle Header/Footer’

4. Removed the Network Site List tab from Main Menu under Network Information.

Site report
1. Added -ms-transform to hopefully get the site triangle to rotate correctly

Coastal report

1. Renamed coastal page region buttons:
       Northeast to “North and Middle Atlantic”
       Southeast to “South Atlantic”
       West to Pacific
       Gulf to Gulf of Mexico

2.  text changed to: Select (or click) on a Region for load and yield graphs

MRB

1. Removed the data download button from the upper right corner of the MRB report page.