### PR TITLE
Updated getYearsByTick to set axis.min to the start of the earliest

### DIFF
--- a/nar_common/static/nar_ui/mississippi/GraphPopup.js
+++ b/nar_common/static/nar_ui/mississippi/GraphPopup.js
@@ -267,8 +267,8 @@ nar.GraphPopup = (function() {
 						timeRange = me.timeSeriesViz.timeSeriesCollection.getTimeRange();
 						// Adjust the axis so the bars are inside the plot
 						options.xaxes.each(function(axis) {
-							axis.min = timeRange.startTime - YEAR_MS;
-							axis.max = timeRange.endTime + YEAR_MS;
+							axis.min = timeRange.startTime;
+							axis.max = timeRange.endTime;
 						});
 						options.legend.show = false;
 

--- a/nar_common/static/nar_ui/plots/PlotUtils.js
+++ b/nar_common/static/nar_ui/plots/PlotUtils.js
@@ -229,10 +229,19 @@ nar.plots = nar.plots || {};
 			 * Use to format time series axis when you want the ticks to represent a year. 
 			 * Can be assigned to the ticks property for an axis.
 			 * @ return Array of utc time.
+			 * side effect is that it updates axis.min to the start of the water year 
+			 * and axis.max to the end of the water year.
 			 */
 			getTicksByYear : function(axis) {
 				var tFirstYear, tLastYear;
 				var thisDate, maxDate;
+
+				// Adjust axis.min and axis.max so that complete bars are shown.
+				var minWy = nar.WaterYearUtils.convertDateToWaterYear(axis.min);
+				var maxWy = nar.WaterYearUtils.convertDateToWaterYear(axis.max);
+				
+				axis.min = nar.WaterYearUtils.getWaterYearStart(minWy, true);
+				axis.max = nar.WaterYearUtils.getWaterYearEnd(maxWy, true);
 
 				var result = axis.tickGenerator(axis);
 				if (result.length > 1) {

--- a/nar_common/static/nar_ui/tests/PlotUtilsSpec.js
+++ b/nar_common/static/nar_ui/tests/PlotUtilsSpec.js
@@ -133,9 +133,8 @@ describe('nar.plots.PlotUtils', function() {
 			getUtcTime = function(year, month, day) {
 				return (new Date(year, month, day)).getTime();
 			};
-			tickGenerator = jasmine.createSpy('tickGenerator');
-			
-		})
+			tickGenerator = jasmine.createSpy('tickGenerator');			
+		});
 		
 		it('Should use the results from tickGenerator if the range of years if larger than the number of results', function() {
 			var axis;
@@ -157,7 +156,7 @@ describe('nar.plots.PlotUtils', function() {
 			
 			axis = {
 				min : (new Date(2008, 0, 1)).getTime(),
-				max : (new Date(2010, 0, 1)).getTime(),
+				max : (new Date(2009, 0, 1)).getTime(),
 				tickGenerator : tickGenerator
 			};
 			expect(nar.plots.PlotUtils.getTicksByYear(axis)).toEqual([getUtcTime(2008, 0, 1), getUtcTime(2009, 0, 1)]);


### PR DESCRIPTION
water year and axis.max to the end of the earliest water year.