### PR TITLE
IE text fix

### DIFF
--- a/nar_common/static/nar_ui/nar.less
+++ b/nar_common/static/nar_ui/nar.less
@@ -1095,7 +1095,7 @@ ul#relativeLinks{
  				border:@fullReportBorder;
  				text-align:left;
  				color:rgb(160,160,160);
- 				font-size:1.1em;
+ 				font-size:1em;
  				border-radius:5px;
  				cursor:pointer;}
  				


### PR DESCRIPTION
Text was wrapping in IE Download Data button on the detailed graph page.  I downed the font-size from 1.1em to 1em and it fixed the issue.