### PR TITLE
Conditional analytics inclusion

### DIFF
--- a/nar_common/templates/base.html
+++ b/nar_common/templates/base.html
@@ -99,6 +99,7 @@ from the top menu bar, selecting ‘Compatibility view settings’, uncheck boxe
 	
 		</script>
 		
+		{% if not settings.DEBUG %}
 		<script>
 			(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function()
 			{ (i[r].q=i[r].q||[]).push(arguments)}
@@ -109,8 +110,9 @@ from the top menu bar, selecting ‘Compatibility view settings’, uncheck boxe
 			ga('set', 'anonymizeIp', true);
 			ga('send', 'pageview');
 		</script>
-		<script type="application/javascript" src="http://www.usgs.gov/scripts/analytics/usgs-analytics.js"></script>
 		
+		<script type="application/javascript" src="http://www.usgs.gov/scripts/analytics/usgs-analytics.js"></script>
+		{% endif %}
 
 
 {% endblock %}


### PR DESCRIPTION
Analytics scripts break when you run them on dev workstations.The error notification popup of the breaking analytics scripts moves the map before the gage layer is loaded, causing hover and click identifications to fail and preventing devs from drilling down on arbitrary sites via the map. This fix prevents bogus analytics from getting recorded on our local or development vms. It also fixes the map identifications so that devs can use the app.