### PR TITLE
Nawqaan 531

### DIFF
--- a/nar_common/static/nar_ui/full_report/main.js
+++ b/nar_common/static/nar_ui/full_report/main.js
@@ -161,16 +161,20 @@ $(document).ready(function() {
 			}
 		});
 		
-		//handle hydrograph special case
+		//Now, since every visualizable constituent and modtype is available in the tsvRegistry,
+		//and every one in the registry is about to be visualized, check to see if the hydrograph 
+		//should be removed. If it shouldn't be removed, override it's time range.
 		var hydrographAndFlowDurationTsvId = 'Q/daily/flow';
 		var hydrographAndFlowDurationTsv = tsvRegistry.get(hydrographAndFlowDurationTsvId);
-		if(isValidHydrographAndFlowDurationTimeSeriesVis(hydrographAndFlowDurationTsv)){
-			//if valid, restrict data's time range to the current water year 
-			hydrographAndFlowDurationTsv.timeSeriesCollection.getAll().each(function(timeSeries){
-				timeSeries.timeRange = nar.timeSeries.WaterYearTimeRange(CONFIG.currentWaterYear);
-			});
-		} else {
-			tsvRegistry.deregister(hydrographAndFlowDurationTsvId);
+		if(hydrographAndFlowDurationTsv){
+			if(isValidHydrographAndFlowDurationTimeSeriesVis(hydrographAndFlowDurationTsv)){
+				//if valid, restrict data's time range to the current water year 
+				hydrographAndFlowDurationTsv.timeSeriesCollection.getAll().each(function(timeSeries){
+					timeSeries.timeRange = nar.timeSeries.WaterYearTimeRange(CONFIG.currentWaterYear);
+				});
+			} else {
+				tsvRegistry.deregister(hydrographAndFlowDurationTsvId);
+			}
 		}
 		
 		var allTimeSeriesVizualizations = tsvRegistry.getAll();

--- a/nar_common/static/nar_ui/full_report/main.js
+++ b/nar_common/static/nar_ui/full_report/main.js
@@ -74,18 +74,17 @@ $(document).ready(function() {
 		return ignore;
 	};
 	
+	var LAST_WATER_YEAR_RANGE = Date.range(nar.WaterYearUtils.getWaterYearStart(CONFIG.currentWaterYear), nar.WaterYearUtils.getWaterYearEnd(CONFIG.currentWaterYear));
 	/**
 	 * Checks to make sure that the data underlying the series cover the
 	 * most recent year.
-	 * @param {nar.timeSeries.Visualization}
+	 * @param {nar.timeSeries.TimeSeriesCollection}
 	 * @returns Boolean - True if valid, false otherwise
 	 */
-	var LAST_WATER_YEAR_RANGE = Date.range(nar.WaterYearUtils.getWaterYearStart(CONFIG.currentWaterYear), nar.WaterYearUtils.getWaterYearEnd(CONFIG.currentWaterYear));
-	var isValidHydrographAndFlowDurationTimeSeriesVis = function(tsv){
+	var isValidHydrographAndFlowDurationTimeSeriesCollection = function(timeSeriesCollection){
 		var valid = true;
-		var tsvCollection = tsv.timeSeriesCollection;
-		if(tsvCollection){
-			valid = tsvCollection.getAll().every(function(timeSeries){
+		if(timeSeriesCollection){
+			valid = timeSeriesCollection.getAll().every(function(timeSeries){
 				var tsvRange = timeSeries.timeRange;
 				var dateRange = Date.range(tsvRange.startTime, tsvRange.endTime);
 				var intersection = dateRange.intersect(LAST_WATER_YEAR_RANGE);
@@ -169,7 +168,7 @@ $(document).ready(function() {
 		var HYDROGRAPH_AND_FLOW_DURATION_TSV_ID = 'Q/daily/flow';
 		var hydrographAndFlowDurationTsv = tsvRegistry.get(HYDROGRAPH_AND_FLOW_DURATION_TSV_ID);
 		if(hydrographAndFlowDurationTsv){
-			if(isValidHydrographAndFlowDurationTimeSeriesVis(hydrographAndFlowDurationTsv)){
+			if(isValidHydrographAndFlowDurationTimeSeriesCollection(hydrographAndFlowDurationTsv.timeSeriesCollection)){
 				//if valid, restrict data's time range to the current water year 
 				hydrographAndFlowDurationTsv.timeSeriesCollection.getAll().each(function(timeSeries){
 					timeSeries.timeRange = nar.timeSeries.WaterYearTimeRange(CONFIG.currentWaterYear);

--- a/nar_common/static/nar_ui/full_report/main.js
+++ b/nar_common/static/nar_ui/full_report/main.js
@@ -74,6 +74,30 @@ $(document).ready(function() {
 		return ignore;
 	};
 	
+	/**
+	 * Checks to make sure that the data underlying the series cover the
+	 * most recent year.
+	 * @param {nar.timeSeries.Visualization}
+	 * @returns Boolean - True if valid, false otherwise
+	 */
+	var lastWaterYearRange = Date.range(nar.WaterYearUtils.getWaterYearStart(CONFIG.currentWaterYear), nar.WaterYearUtils.getWaterYearEnd(CONFIG.currentWaterYear));
+	var isValidHydrographAndFlowDurationTimeSeriesVis = function(tsv){
+		var valid = true;
+		var tsvCollection = tsv.timeSeriesCollection;
+		if(tsvCollection){
+			valid = tsvCollection.getAll().every(function(timeSeries){
+				var tsvRange = timeSeries.timeRange;
+				var dateRange = Date.range(tsvRange.startTime, tsvRange.endTime);
+				var intersection = dateRange.intersect(lastWaterYearRange);
+				var tsvRangeAndLastWaterYearRangeIntersect = intersection.isValid();
+				return tsvRangeAndLastWaterYearRangeIntersect;
+			});
+		}
+		else{
+			valid = false;
+		}
+		return valid;
+	};
 	var tsvRegistry = nar.timeSeries.VisualizationRegistryInstance;
 	var successfulGetDataAvailability = function(data,
 			textStatus, jqXHR) {
@@ -138,6 +162,13 @@ $(document).ready(function() {
 				}
 			}
 		});
+		
+		
+		var hydrographAndFlowDurationTsvId = 'Q/daily/flow';
+		var hydrographAndFlowDurationTsv = tsvRegistry.get(hydrographAndFlowDurationTsvId);
+		if(!isValidHydrographAndFlowDurationTimeSeriesVis(hydrographAndFlowDurationTsv)){
+			tsvRegistry.deregister(hydrographAndFlowDurationTsvId);
+		}
 		
 		var allTimeSeriesVizualizations = tsvRegistry.getAll();
 		var timeSlider = nar.timeSeries.TimeSlider(selectorElementPairs.timeSlider.element);

--- a/nar_common/static/nar_ui/full_report/main.js
+++ b/nar_common/static/nar_ui/full_report/main.js
@@ -86,11 +86,8 @@ $(document).ready(function() {
 		var tsvCollection = tsv.timeSeriesCollection;
 		if(tsvCollection){
 			valid = tsvCollection.getAll().every(function(timeSeries){
-				var tsvRange = timeSeries.timeRange;
-				var dateRange = Date.range(tsvRange.startTime, tsvRange.endTime);
-				var intersection = dateRange.intersect(lastWaterYearRange);
-				var tsvRangeAndLastWaterYearRangeIntersect = intersection.isValid();
-				return tsvRangeAndLastWaterYearRangeIntersect;
+				var data = timeSeries.data;
+				return undefined != data;
 			});
 		}
 		else{
@@ -134,9 +131,7 @@ $(document).ready(function() {
 						tsvRegistry.register(timeSeriesViz);
 					}
 		
-					var timeRange = timeSeriesViz
-							.ranger(dataAvailability);
-		
+					var timeRange = nar.timeSeries.DataAvailabilityTimeRange(dataAvailability);
 					var timeSeries = new nar.timeSeries.TimeSeries(
 							{
 								observedProperty : observedProperty,
@@ -163,10 +158,15 @@ $(document).ready(function() {
 			}
 		});
 		
-		
+		//handle hydrograph special case
 		var hydrographAndFlowDurationTsvId = 'Q/daily/flow';
 		var hydrographAndFlowDurationTsv = tsvRegistry.get(hydrographAndFlowDurationTsvId);
-		if(!isValidHydrographAndFlowDurationTimeSeriesVis(hydrographAndFlowDurationTsv)){
+		if(isValidHydrographAndFlowDurationTimeSeriesVis(hydrographAndFlowDurationTsv)){
+			//if valid, restrict data's time range to the current water year 
+			hydrographAndFlowDurationTsv.timeSeriesCollection.getAll().each(function(timeSeries){
+				timeSeries.timeRange = nar.timeSeries.WaterYearTimeRange(CONFIG.currentWaterYear);
+			});
+		} else {
 			tsvRegistry.deregister(hydrographAndFlowDurationTsvId);
 		}
 		

--- a/nar_common/static/nar_ui/full_report/main.js
+++ b/nar_common/static/nar_ui/full_report/main.js
@@ -86,8 +86,11 @@ $(document).ready(function() {
 		var tsvCollection = tsv.timeSeriesCollection;
 		if(tsvCollection){
 			valid = tsvCollection.getAll().every(function(timeSeries){
-				var data = timeSeries.data;
-				return undefined != data;
+				var tsvRange = timeSeries.timeRange;
+				var dateRange = Date.range(tsvRange.startTime, tsvRange.endTime);
+				var intersection = dateRange.intersect(lastWaterYearRange);
+				var tsvRangeAndLastWaterYearRangeIntersect = intersection.isValid();
+				return tsvRangeAndLastWaterYearRangeIntersect;
 			});
 		}
 		else{

--- a/nar_common/static/nar_ui/full_report/main.js
+++ b/nar_common/static/nar_ui/full_report/main.js
@@ -19,7 +19,7 @@ $(document).ready(function() {
 	};
 	nar.timeSeries.VisualizationRegistryInstance = new nar.timeSeries.VisualizationRegistry();
 
-	var getDataAvailabilityUri = CONFIG.endpoint.sos + '/json';
+	var GET_DATA_AVAILABILITY_URL = CONFIG.endpoint.sos + '/json';
 	var getDataAvailabilityParams = {
 		"request" : "GetDataAvailability",
 		"service" : "SOS",
@@ -28,12 +28,12 @@ $(document).ready(function() {
 	};
 
 	var getDataAvailabilityRequest = $.ajax({
-		url : getDataAvailabilityUri,
+		url : GET_DATA_AVAILABILITY_URL,
 		data : JSON.stringify(getDataAvailabilityParams),
 		type : 'POST',
 		contentType : 'application/json'
 	});
-	var acceptableComponentsGroup = [
+	var ACCEPTABLE_COMPONENTS_GROUP = [
           {
     	  	  timestepDensity: 'discrete',
         	  category: 'concentration'
@@ -56,7 +56,7 @@ $(document).ready(function() {
         	  subcategory: undefined
           }
     ];
-	var constituentsToKeep = ['nitrogen', 'nitrate', 'streamflow', 'phosphorus', 'sediment'];
+	var CONSTITUENTS_TO_KEEP = ['nitrogen', 'nitrate', 'streamflow', 'phosphorus', 'sediment'];
 	/**
 	 * Determines if 'components' should be displayed on the client or not
 	 * @param {nar.timeSeries.Visualization.IdComponents} components, as returned by nar.TimeSeries.Visualization.getComponentsOfId 
@@ -80,7 +80,7 @@ $(document).ready(function() {
 	 * @param {nar.timeSeries.Visualization}
 	 * @returns Boolean - True if valid, false otherwise
 	 */
-	var lastWaterYearRange = Date.range(nar.WaterYearUtils.getWaterYearStart(CONFIG.currentWaterYear), nar.WaterYearUtils.getWaterYearEnd(CONFIG.currentWaterYear));
+	var LAST_WATER_YEAR_RANGE = Date.range(nar.WaterYearUtils.getWaterYearStart(CONFIG.currentWaterYear), nar.WaterYearUtils.getWaterYearEnd(CONFIG.currentWaterYear));
 	var isValidHydrographAndFlowDurationTimeSeriesVis = function(tsv){
 		var valid = true;
 		var tsvCollection = tsv.timeSeriesCollection;
@@ -88,7 +88,7 @@ $(document).ready(function() {
 			valid = tsvCollection.getAll().every(function(timeSeries){
 				var tsvRange = timeSeries.timeRange;
 				var dateRange = Date.range(tsvRange.startTime, tsvRange.endTime);
-				var intersection = dateRange.intersect(lastWaterYearRange);
+				var intersection = dateRange.intersect(LAST_WATER_YEAR_RANGE);
 				var tsvRangeAndLastWaterYearRangeIntersect = intersection.isValid();
 				return tsvRangeAndLastWaterYearRangeIntersect;
 			});
@@ -116,8 +116,8 @@ $(document).ready(function() {
 						.getTimeSeriesVisualizationId(observedProperty, procedure);
 				var timeSeriesIdComponents = nar.timeSeries.Visualization.getComponentsOfId(timeSeriesVizId);
 				
-				if(		!constituentsToKeep.some(timeSeriesIdComponents.constituent) 
-						|| componentsAreIgnorable(timeSeriesIdComponents, acceptableComponentsGroup)){
+				if(		!CONSTITUENTS_TO_KEEP.some(timeSeriesIdComponents.constituent) 
+						|| componentsAreIgnorable(timeSeriesIdComponents, ACCEPTABLE_COMPONENTS_GROUP)){
 					return;//continue
 				}
 				else{
@@ -166,8 +166,8 @@ $(document).ready(function() {
 		//Now, since every non-ignored constituent and modtype is available in the tsvRegistry,
 		//and every one in the registry is about to be visualized, check to see if the hydrograph 
 		//should be removed. If it shouldn't be removed, override it's time range.
-		var hydrographAndFlowDurationTsvId = 'Q/daily/flow';
-		var hydrographAndFlowDurationTsv = tsvRegistry.get(hydrographAndFlowDurationTsvId);
+		var HYDROGRAPH_AND_FLOW_DURATION_TSV_ID = 'Q/daily/flow';
+		var hydrographAndFlowDurationTsv = tsvRegistry.get(HYDROGRAPH_AND_FLOW_DURATION_TSV_ID);
 		if(hydrographAndFlowDurationTsv){
 			if(isValidHydrographAndFlowDurationTimeSeriesVis(hydrographAndFlowDurationTsv)){
 				//if valid, restrict data's time range to the current water year 
@@ -175,7 +175,7 @@ $(document).ready(function() {
 					timeSeries.timeRange = nar.timeSeries.WaterYearTimeRange(CONFIG.currentWaterYear);
 				});
 			} else {
-				tsvRegistry.deregister(hydrographAndFlowDurationTsvId);
+				tsvRegistry.deregister(HYDROGRAPH_AND_FLOW_DURATION_TSV_ID);
 			}
 		}
 		

--- a/nar_common/static/nar_ui/full_report/main.js
+++ b/nar_common/static/nar_ui/full_report/main.js
@@ -102,7 +102,7 @@ $(document).ready(function() {
 	var successfulGetDataAvailability = function(data,
 			textStatus, jqXHR) {
 		var dataAvailability = data.dataAvailability;
-				
+		//populate the tsvRegistry with tsvs created from the GetDataAvailability response 
 		dataAvailability.each(function(dataAvailability) {
 			var observedProperty = dataAvailability.observedProperty;
 			var procedure = dataAvailability.procedure;
@@ -133,7 +133,9 @@ $(document).ready(function() {
 								});
 						tsvRegistry.register(timeSeriesViz);
 					}
-		
+					
+					//Use the default time ranger for now. Override the hydrograph's time range 
+					//later if both of its time series overlap with the most recent water year.
 					var timeRange = nar.timeSeries.DataAvailabilityTimeRange(dataAvailability);
 					var timeSeries = new nar.timeSeries.TimeSeries(
 							{
@@ -161,7 +163,7 @@ $(document).ready(function() {
 			}
 		});
 		
-		//Now, since every visualizable constituent and modtype is available in the tsvRegistry,
+		//Now, since every non-ignored constituent and modtype is available in the tsvRegistry,
 		//and every one in the registry is about to be visualized, check to see if the hydrograph 
 		//should be removed. If it shouldn't be removed, override it's time range.
 		var hydrographAndFlowDurationTsvId = 'Q/daily/flow';

--- a/nar_common/static/nar_ui/tests/TimeSeriesVisualizationRegistrySpec.js
+++ b/nar_common/static/nar_ui/tests/TimeSeriesVisualizationRegistrySpec.js
@@ -74,5 +74,18 @@ $(document).ready(function(){
 					expect(output).toBe(expectedOutput);
 				});
 			});
+			it('returns false if user calls deregister() with a key that has not yet been registered', function(){
+				expect(tsvRegistry.deregister('mockId')).toBe(false);
+			});
+			it('returns true if user calls deregister() with a key that has not yet been registered', function(){
+				tsvRegistry.register(tsv);
+				var wasRegistered = tsvRegistry.deregister(tsv.id);
+				expect(wasRegistered).toBe(true);
+			});
+			it('"get()" should return undefined for an id after "deregister()" is called with that id', function(){
+				tsvRegistry.register(tsv);
+				tsvRegistry.deregister(tsv.id);
+				expect(tsvRegistry.get(tsv.id)).toBeUndefined();
+			});
 	});
 });

--- a/nar_common/static/nar_ui/tests/TimeSeriesVisualizationRegistrySpec.js
+++ b/nar_common/static/nar_ui/tests/TimeSeriesVisualizationRegistrySpec.js
@@ -77,7 +77,7 @@ $(document).ready(function(){
 			it('returns false if user calls deregister() with a key that has not yet been registered', function(){
 				expect(tsvRegistry.deregister('mockId')).toBe(false);
 			});
-			it('returns true if user calls deregister() with a key that has not yet been registered', function(){
+			it('returns true if user calls deregister() with a key that has been registered', function(){
 				tsvRegistry.register(tsv);
 				var wasRegistered = tsvRegistry.deregister(tsv.id);
 				expect(wasRegistered).toBe(true);

--- a/nar_common/static/nar_ui/time_series/TimeSeriesVisualization.js
+++ b/nar_common/static/nar_ui/time_series/TimeSeriesVisualization.js
@@ -21,7 +21,6 @@ nar.timeSeries.Visualization = function(config){
     self.allPlotsWrapperElt = config.allPlotsWrapperElt;
     self.treeDisplayHierarchy = config.treeDisplayHierarchy || '';
     self.plotter = config.plotter;
-    self.ranger = nar.timeSeries.Visualization.getCustomizationById(self.id, 'range', nar.util.Unimplemented);
     self.ancillaryData = nar.timeSeries.Visualization.getCustomizationById(self.id, 'ancillary', []);
     self.auxData = config.auxData || {};
     self.allowTimeSlider = nar.timeSeries.Visualization.getCustomizationById(self.id, 'allowTimeSlider', true);
@@ -207,14 +206,12 @@ nar.timeSeries.Visualization.types = function(components) {
 			if (components.subcategory === 'mean' || components.subcategory === 'flow_weighted') {
 				return {
 					plotter : nar.plots.createConcentrationPlot,
-					range : nar.timeSeries.DataAvailabilityTimeRange,
 					ancillary : [],
 					allowTimeSlider : true
 				};
 			}
 			else return {
 				plotter : nar.plots.SampleConcentrationPlot,
-				range : nar.timeSeries.DataAvailabilityTimeRange,
 				ancillary : [],
 				allowTimeSlider : true
 			};
@@ -222,7 +219,6 @@ nar.timeSeries.Visualization.types = function(components) {
 		else if (components.category === 'mass') {
 			return {
 				plotter : nar.plots.LoadPlot,
-				range : nar.timeSeries.DataAvailabilityTimeRange,
 				ancillary : [],
 				allowTimeSlider : true
 			};
@@ -231,7 +227,6 @@ nar.timeSeries.Visualization.types = function(components) {
 			if (components.timestepDensity === 'annual') {
 				return {
 					plotter : nar.plots.createFlowPlot,
-					range : nar.timeSeries.DataAvailabilityTimeRange,
 					ancillary : [],
 					allowTimeSlider : true
 				};
@@ -239,9 +234,7 @@ nar.timeSeries.Visualization.types = function(components) {
 			else {
 				return {
 					plotter : nar.plots.FlowWrapper,
-					range : function() {
-						return nar.timeSeries.WaterYearTimeRange(CONFIG.currentWaterYear);
-					},
+
 					ancillary : [{
 						// @todo We will want to store these somewhere so this can just be nar .discrete.nitrogen
 						procedure : CONFIG.sosDefsBaseUrl + "procedure/discrete_concentration",

--- a/nar_common/static/nar_ui/time_series/TimeSeriesVisualization.js
+++ b/nar_common/static/nar_ui/time_series/TimeSeriesVisualization.js
@@ -6,7 +6,7 @@ nar.timeSeries  = nar.timeSeries || {};
  * @typedef nar.timeSeries .TimeSeriesVisualizationConfig
  * @property {string} id
  * @property {Function} plotter
- * @property {nar.timeSeries .TimeSeriesCollection} timeSeriesCollection
+ * @property {nar.timeSeries.TimeSeriesCollection} timeSeriesCollection
  * @property {String} treeDisplayHierarchy optional param describing location of time series in a tree
  * @property {jQuery} allPlotsWrapperElt
  */

--- a/nar_common/static/nar_ui/time_series/TimeSeriesVisualizationRegistry.js
+++ b/nar_common/static/nar_ui/time_series/TimeSeriesVisualizationRegistry.js
@@ -59,6 +59,18 @@ nar.timeSeries.VisualizationRegistry = function(){
         }
     };
     /**
+     * @param {String Time Series Visualization Id}
+     * @returns Boolean - true if the requested id was registered, false otherwise 
+     */
+    self.deregister = function(timeSeriesVisualizationId){
+    	var wasRegistered = false;
+    	if(Object.has(entries, timeSeriesVisualizationId)){
+    		wasRegistered = true;
+    		delete entries[timeSeriesVisualizationId];
+    	}
+    	return wasRegistered;
+    };
+    /**
      * Return all registered time series visualizations
      * @returns {Array<nar.timeSeries.Visualization>}
      */


### PR DESCRIPTION
The hydrograph requires two time series: daily flow, total nitrogen sample concentration. The hydrograph only displays data from last water year. We ran into a problem where some sites only had data from last water year in one of the required time series. We need to prohibit the visualization of the Hydrograph TimeSeriesVisualization (HTSV) if any of the two time series associated with the HTSV do not overlap with the last water year.  I moved hydrograph time range customization out of the TimeSeriesVisualization class and into the full reports' main.js. I did this because it was simpler to filter the TSVs after all of the getDataAvailability entries had all been processed, rather than trying to track state within the loop processing the getDataAvailability responses into TSVs. 