### PR TITLE
Added an id parameter to all POSTs to the SOS server. I used a hash

### DIFF
--- a/nar_common/static/nar_ui/coastal_region/main.js
+++ b/nar_common/static/nar_ui/coastal_region/main.js
@@ -52,20 +52,21 @@
 			var tickLabels = basinFeatures.map(function(value) {
 				return value.attributes[CONFIG.riverNameAttribute].replace('River', '\nRiver');
 			});
+			var requestParamsString = JSON.stringify({
+				'request' : 'GetDataAvailability',
+				'service' : 'SOS',
+				'version' : '2.0.0',
+				'observedProperty' : CONFIG.sosDefsBaseUrl + 'property/NO3_NO2',
+				'featureOfInterest' : basinSiteIds
+			});
 			
 			// Make dataAvailability call for all sites for nitrate and nitrite
 			var getDataAvailability = $.ajax({
-				url : CONFIG.endpoint.sos,
+				url : CONFIG.endpoint.sos + '?id=' + nar.util.getHashCode(requestParamsString),
 				contentType : 'application/json',
 				type: 'POST',
 				dataType : 'json',
-				data : JSON.stringify({
-					'request' : 'GetDataAvailability',
-					'service' : 'SOS',
-					'version' : '2.0.0',
-					'observedProperty' : CONFIG.sosDefsBaseUrl + 'property/NO3_NO2',
-					'featureOfInterest' : basinSiteIds
-				})
+				data : requestParamsString
 			});
 
 			$.when(getDataAvailability)

--- a/nar_common/static/nar_ui/full_report/main.js
+++ b/nar_common/static/nar_ui/full_report/main.js
@@ -26,10 +26,12 @@ $(document).ready(function() {
 		"version" : "2.0.0",
 		"featureOfInterest" : PARAMS.siteId
 	};
+	
+	var requestParamsString = JSON.stringify(getDataAvailabilityParams);
 
 	var getDataAvailabilityRequest = $.ajax({
-		url : GET_DATA_AVAILABILITY_URL,
-		data : JSON.stringify(getDataAvailabilityParams),
+		url : GET_DATA_AVAILABILITY_URL + '?id=' + nar.util.getHashCode(requestParamsString),
+		data : requestParamsString,
 		type : 'POST',
 		contentType : 'application/json'
 	});

--- a/nar_common/static/nar_ui/mississippi/GraphPopup.js
+++ b/nar_common/static/nar_ui/mississippi/GraphPopup.js
@@ -48,18 +48,19 @@ nar.GraphPopup = (function() {
 		}
 		var constituentId = mrbToSos.constituentToConstituentId[mrbConstituent];
 		var observedProperty = observedPropertyBaseUrl + constituentId;
+		var requestParamsString = JSON.stringify({
+			"request": "GetDataAvailability",
+			"service": "SOS",
+			"version": "2.0.0",
+			"observedProperty": observedProperty,
+			"featureOfInterest": siteId
+		});
 		var getDataAvailability = $.ajax({
-			url: CONFIG.endpoint.sos,
+			url: CONFIG.endpoint.sos + '?id=' + nar.util.getHashCode(requestParamsString),
 			contentType : 'application/json',
 			type: 'POST',
 			dataType: 'json',
-			data: JSON.stringify({
-				  "request": "GetDataAvailability",
-				  "service": "SOS",
-				  "version": "2.0.0",
-				  "observedProperty": observedProperty,
-				  "featureOfInterest": siteId
-			})
+			data: requestParamsString
 		});
 		
 		$.when(getDataAvailability).then(function(dataAvailability){

--- a/nar_common/static/nar_ui/summary_report/main.js
+++ b/nar_common/static/nar_ui/summary_report/main.js
@@ -129,18 +129,19 @@ $(document).ready(
 						barChart, series);
 			};
 
+			var requestParamsString = JSON.stringify({
+				'request' : 'GetDataAvailability',
+				'service' : 'SOS',
+				'version' : '2.0.0',
+				'featureOfInterest' : id
+			});
 			//find out what data is available for the site
 			var getDataAvailability = $.ajax({
-				url : CONFIG.endpoint.sos + '/json',
+				url : CONFIG.endpoint.sos + '/json?id=' + nar.util.getHashCode(requestParamsString),
 				contentType : 'application/json',
 				type: 'POST',
 				dataType : 'json',
-				data : JSON.stringify({
-					'request' : 'GetDataAvailability',
-					'service' : 'SOS',
-					'version' : '2.0.0',
-					'featureOfInterest' : id
-				})
+				data : requestParamsString
 			});
 
 			var streamflowDataAvailability = [];

--- a/nar_common/static/nar_ui/time_series/TimeSeries.js
+++ b/nar_common/static/nar_ui/time_series/TimeSeries.js
@@ -91,12 +91,15 @@ nar.timeSeries.TimeSeries = function(config){
 		}
         
         var deferred = $.Deferred();
+        
+        var resultParamString = JSON.stringify(getResultParams);
 
         var dataRetrieval = $.ajax({
-            url: CONFIG.endpoint.sos + '/json',
+            url: CONFIG.endpoint.sos + '/json?id=' + nar.util.getHashCode(resultParamString),
             type: 'POST',
-            data: JSON.stringify(getResultParams),
+            data: resultParamString,
             contentType:'application/json',
+            dataType : 'json',
             success: function(response, textStatus, jqXHR){
                 self.data = self.parseSosGetResultResponse(response);
                 if (!self.timeRange) {

--- a/nar_common/static/nar_ui/util.js
+++ b/nar_common/static/nar_ui/util.js
@@ -74,5 +74,16 @@ nar.util = {};
 			return myString.has(ignoredModtype);
 		});
 	};
+	
+	nar.util.getHashCode = function(str) {
+		var hash = 0, i, chr, len;
+		if (str.length === 0) return hash;
+		for (i = 0; i < str.length; i++) {
+			chr   = str.charCodeAt(i);
+			hash  = ((hash << 5) - hash) + chr;
+			hash |= 0; // Convert to 32bit integer
+		}
+		return hash;
+	};
     
 }());


### PR DESCRIPTION
function that I got from
http://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript-jquery.

Using an id parameter on the POST's url makes the POST url unique for
each POST to get a unique resource. This prevents Safari from using the
cached response.

This solution was suggested by http://www.artermobilize.com/blog/2015/06/17/safari-back-button-and-web-service-response-behaviour/