### PR TITLE
correct labels

### DIFF
--- a/nar_common/static/nar_ui/summary_report/main.js
+++ b/nar_common/static/nar_ui/summary_report/main.js
@@ -427,13 +427,13 @@ $(document).ready(
 							else if(type === '%' && benchmark === 'aquatic'){
 								mapping.values = ['percAqOld', 'percAq3', 'percAq'];
 								mapping.analyzed = ['nOldAve', 'n3', 'nNew'];
-								mapping.wBenchmarks = ['nOldAq', 'nAq3', 'nNewAq'];
+								mapping.wBenchmarks = ['nOldAq', 'npest3Aq', 'nNewAq'];
 							}
 							else if(type === 'number' && benchmark === 'aquatic'){
 								mapping.values = ['nAqOld', 'nAq3', 'nAq'];
 								mapping.exceedances = ['pestOldExceedAq', 'pest3ExceedAq', 'pestNewExceedAq'];
-								mapping.analyzed = ['nOldAve', 'npest3Aq', 'nNew'];
-								mapping.wBenchmarks = ['nOldAq', 'nAq3', 'nNewAq'];
+								mapping.analyzed = ['nOldAve', 'n3', 'nNew'];
+								mapping.wBenchmarks = ['nOldAq', 'npest3Aq', 'nNewAq'];
 							}
 							//Expects an array of an array
 							result.values = mapping.values.map(function(slot){


### PR DESCRIPTION
@cschroed-usgs Changed based on Casey's comment on https://internal.cida.usgs.gov/jira/browse/NAWQAAN-639
"The labels are fine as is, this field was for the text that went with the graphs. See examples from the Shiny page where it says "Of __ samples analyzed for as many as __ pesticides with acute or chronic aquatic-life benchmarks. This field was to fill the second blank of the 2013 bar."

So we should be good after this...hopefully if I understood it correctly