### PR TITLE
detailed pesticide graphs

### DIFF
--- a/nar_common/static/nar_ui/commons/SiteIdentificationControl.js
+++ b/nar_common/static/nar_ui/commons/SiteIdentificationControl.js
@@ -54,10 +54,12 @@ nar.SiteIdentificationControl = OpenLayers.Class(OpenLayers.Control.WMSGetFeatur
 					$reportsAndGraphsRow = $('<div />').addClass('row site-identification-popup-content-links-and-graphs'),
 					$summaryGraphsLinkContainer = $('<div />').addClass('col-xs-6 col-md-4 site-identification-popup-content-summary-graph-link'),
 					$detailedGraphsLinkContainer = $('<div />').addClass('col-xs-6 col-md-4 site-identification-popup-content-detailed-graph-link'),
+					$detailedPesticideGraphsLinkContainer = $('<div />').addClass('col-xs-6 col-md-4 site-identification-popup-content-detailed-pesticides-graph-link'),
 					$downloadLinkContainer = $('<div />').addClass('col-xs-6 col-md-4 site-identification-popup-content-download-link'),
 					$summaryGraphsLink = $('<a />').append($('<span />').addClass('glyphicon glyphicon-th-list'),' Summary Graphs'),
 					$detailedGraphsLink = $('<a />').append($('<span />').addClass('glyphicon glyphicon-stats'), ' Detailed Graphs'),
 					$downloadLink = $('<a />').append($('<span />').addClass('glyphicon glyphicon-save'),' Download Data'),
+					$detailedPesticdeGraphsLink = $('<a />').append($('<span />').addClass('glyphicon glyphicon-stats'), ' Detailed Pesticide Graphs'),
 					// query-ui has a hierarchy of things it tries to auto-focus on. This hack has it auto-focus on a hidden span.
 					// Otherwise it trues to focus on the first link, which in some browsers will draw an outline around it. (ugly)
 					// http://api.jqueryui.com/dialog/
@@ -72,12 +74,14 @@ nar.SiteIdentificationControl = OpenLayers.Class(OpenLayers.Control.WMSGetFeatur
 				$summaryGraphsLink.attr('href', CONFIG.summarySiteUrl(id));
 				$detailedGraphsLink.attr('href', CONFIG.detailSiteUrl(id));
 				$downloadLink.attr('href', CONFIG.downloadPageUrl);
+				$detailedPesticdeGraphsLink.attr('href', CONFIG.detailPesticideSiteUrl(id));
 				
 				$summaryGraphsLinkContainer.append($summaryGraphsLink);
 				$detailedGraphsLinkContainer.append($detailedGraphsLink);
 				$downloadLinkContainer.append($downloadLink);
+				$detailedPesticideGraphsLinkContainer.append($detailedPesticdeGraphsLink);
 				
-				$reportsAndGraphsRow.append($summaryGraphsLinkContainer, $detailedGraphsLinkContainer, $downloadLinkContainer, $hiddenAutoFocus);
+				$reportsAndGraphsRow.append($summaryGraphsLinkContainer, $detailedGraphsLinkContainer, $downloadLinkContainer, $detailedPesticideGraphsLinkContainer, $hiddenAutoFocus);
 				
 				$container.append($titleRow, $stationIdRow, $reportsAndGraphsRow);
 				return $container;

--- a/nar_common/static/nar_ui/nar.less
+++ b/nar_common/static/nar_ui/nar.less
@@ -287,6 +287,11 @@ blockquote{
  /*###########################home_end####################### */
 
  /*###########################site_start####################### */
+ 
+.site-identification-popup-content-detailed-pesticides-graph-link{
+	width:40%; 
+	margin:10px 0;
+}
 
 .content{background:none;
         min-height:100%;
@@ -302,7 +307,7 @@ blockquote{
 .site_title h3{
 	padding-top:25px;
  	margin:0 0 2px 0;
- 	font-size:1.6em;}
+ 	font-size:1.5em;}
      
 .site_map{background:@boxColor;
             height:@homePageContentHeight;
@@ -1072,13 +1077,17 @@ ul#relativeLinks{
   		
   }
   
- .site h2{	margin-bottom:-8px;
- 			font-size:1.8em;}
+ .site h2{	
+ 	font-size:1.6em;
+	width:65%;
+	margin:30px auto -10px auto;
+}
  
  .col-lg-1{padding-left:0;}
  
   
 .full_report,
+.pesticide_report,
 .back_to_report,
 .back_to_site,
 .back_to_site_right,
@@ -1096,47 +1105,63 @@ ul#relativeLinks{
  				
  #summaryDownload{text-align:center;
  					right:10px;
- 					bottom:55px;
+ 					bottom:90px;
  					color:#000;}
  				
- .full_report{right:10px;
- 				bottom:10px;}
+ .full_report{
+	right:10px;
+ 	bottom:50px;
+}
+
+.pesticide_report{
+	right:10px;
+	bottom:10px;
+}
  				
  .full_report:hover,
+ .pesticide_report:hover,
  .back_to_site:hover,
  .back_to_site_right:hover,
  #summaryDownload:hover,
  #fullDownload:hover{background:rgb(210,210,210);}
  
- .full_report ul{background:none;
-			list-style-type:none;
-			padding-left:0;
-			height:35px;
-			width:130px;
-			font-family:@baseFontFamily;
-			font-weight:@baseFontWeightReg;
-			float:left;
+ .full_report ul,
+ .pesticide_report ul{
+	background:none;
+	list-style-type:none;
+	padding-left:0;
+	height:35px;
+	width:130px;
+	font-family:@baseFontFamily;
+	font-weight:@baseFontWeightReg;
+	float:left;
 }
 
- .full_report ul li{background:none;
-				display:inline-block;
-				width:130px;
-				height:35px;
-				padding:4px 0 0 10px;
-				cursor:pointer;
-				margin-bottom:12px;
-				float:left;
+ .full_report ul li,
+ .pesticide_report ul li{
+	background:none;
+	display:inline-block;
+	width:130px;
+	height:34px;
+	padding:5px 0 0 10px;
+	cursor:pointer;
+	margin-bottom:12px;
+	float:left;
 				}
 
-.full_report ul li a{color:#000;
-						text-decoration:none;
-						font-size:1.1em;
+.full_report ul li a,
+.pesticide_report ul li a{
+	color:#000;
+	text-decoration:none;
+	font-size:1.1em;
 }
  
- .full_report i{margin-top:8px;
- 					position:absolute;
- 					right:10px;
- 					color:#000;
+ .full_report i,
+ .pesticide_report i{
+	margin-top:8px;
+	position:absolute;
+ 	right:10px;
+ 	color:#000;
  }
  
  .back_to_site,
@@ -1793,21 +1818,29 @@ ul#relativeLinks{
 	.site{height:140px;
 	  	border-bottom:@borderDark;}
 	  		
-	.site h2{font-size:1.6em;}
+	.site h2{
+		font-size:1.6em;
+		width:60%;
+		margin:10px auto -10px auto;
+	}
 	 
 	.site h3{font-size:1.4em;}
 	
-	#summaryDownload{bottom:50px;}
+	#summaryDownload{bottom:90px;}
 	
 	.full_report,
-	#summaryDownload{height:35px;
+	#summaryDownload,
+	.pesticide_report{height:35px;
 					width:140px;}
 	 				
-	 .full_report ul li{padding-top:5px;}
+	 .full_report ul li,
+	 .pesticide_report ul li{padding-top:5px;}
 	 				
-	 .full_report ul li a{font-size:1em;}
+	 .full_report ul li a,
+	 .pesticide_report ul li a{font-size:1em;}
 	 
-	 .full_report i{margin-top:8px;
+	 .full_report i,
+	 .pesticide_report i{margin-top:8px;
 	 				right:5px;
 	 }
 	
@@ -1978,20 +2011,30 @@ ul#relativeLinks{
 				
 	.graphs{height:100%;} 
 	
-	#summaryDownload{bottom:50px;}
+	#summaryDownload{bottom:90px;}
 	
 	.full_report,
-	#summaryDownload{height:35px;
-					width:140px;}
+	#summaryDownload,
+	.pesticide_report{
+		height:35px;
+		width:140px;
+	}
 	 				
-	 .full_report ul li{padding-top:5px;}
+	 .full_report ul li,
+	 .pesticide_report ul li{
+		padding-top:5px;
+	}
 	 				
-	 .full_report ul li a{font-size:1em !important;
-	 				padding-top:4px !important;
+	 .full_report ul li a,
+	 .pesticide_report ul li a{
+		font-size:1em !important;
+	 	padding-top:4px !important;
 	 }
 	 
-	 .full_report i{margin-top:8px;
-	 				right:10px;
+	 .full_report i,
+	 .pesticide_report i{
+		margin-top:8px;
+	 	right:10px;
 	 }
 	
 	/*###################################### */

--- a/nar_common/templates/base.html
+++ b/nar_common/templates/base.html
@@ -69,6 +69,10 @@ from the top menu bar, selecting ‘Compatibility view settings’, uncheck boxe
             gulfHypoxicExtentUrl : "{% url 'nar_values-gulf_hypoxic_extent' %}",
             mrbSubBasinContributionsUrl : "{% url 'nar_values-mrbSubBasinContributions' %}",
             downloadPageUrl : "{% url 'download' %}",
+            detailPesticidePageUrl : "{% url 'pesticide_graphs' '' %}",
+            detailPesticideSiteUrl : function(siteid) {
+                return CONFIG.detailPesticidePageUrl.replace('//', '/' + siteid + '/');                
+            },
             detailPageUrl : "{% url 'detailed_graphs' '' %}",
             detailSiteUrl : function(siteid) {
                 return CONFIG.detailPageUrl.replace('//', '/' + siteid + '/');                

--- a/nar_common/templates/nar_ui/summary.html
+++ b/nar_common/templates/nar_ui/summary.html
@@ -56,7 +56,7 @@
 <div class="row summary_info">
 
 	<div class="col-lg-12 site col-md-12 col-sm-12 col-xs-12">
-		<h2>{{ site_name }}</h2>
+		<h2 class="siteName">{{ site_name }}</h2>
 		<h3>Station ID: {{ site_id }}</h3>
 		<h4>
 			<i>Summary of Water-Quality Conditions for {{ settings.NAR_CURRENT_WATER_YEAR }}</i>
@@ -65,12 +65,15 @@
 		<a href="{% url 'download' %}"><button id="summaryDownload">Download Data</button></a>
 
 		<div class="col-lg-1 full_report col-md-1 col-sm-1 col-xs-1">
-
 			<ul>
 				<li><a href="{% url 'detailed_graphs' site_id %}">Detailed Graphs<i class="glyphicon glyphicon-arrow-right"></i></a></li>
-
 			</ul>
-
+		</div>
+		
+		<div class="col-lg-1 pesticide_report col-md-1 col-sm-1 col-xs-1">
+			<ul>
+				<li><a href="{% url 'pesticide_graphs' site_id %}">Pesticide Graphs<i class="glyphicon glyphicon-arrow-right"></i></a></li>
+			</ul>
 		</div>
 		
 		<a href="{% url 'site' %}"><div class="col-lg-1 back_to_site">Back to Map</div></a>


### PR DESCRIPTION
@cschroed-usgs added a link to the sites detailed pesticide graphs in the map pop up, and from the summary page. I am pretty positive I did it right since clicking the button takes you to the correct area, but let me know if I screwed up anywhere.

Also some CSS changes to allow the third button on the summary page to not block the site ID name on the summary page. And some reformatting cause I wrote this CSS when I was inexperienced and it is driving me nuts.