### PR TITLE
Pesticide Graph Toggle for Summary Page

### DIFF
--- a/nar_common/static/nar_ui/summary.less
+++ b/nar_common/static/nar_ui/summary.less
@@ -47,6 +47,33 @@
 @insetWidth: 230px;
 
 @insetHeight: 230px;
+
+/*options bar*/
+.summaryOptionsBar{
+	min-height:30px;
+	padding:10px;
+	clear:both;
+	border-bottom:@borderDark;
+	text-align:right;
+	
+	button{
+		background:#fff;
+		border:@borderDark;	
+		padding:3px 10px;
+		border-radius:5px;
+		
+		&:hover{
+			background:@primaryColor;
+			color:#fff;	
+		}
+	}
+}
+
+.spotme{
+	clear:none !important;
+}
+
+
 /*No Pesticide Data CSS*/
 #noPesticideData{
 	background:rgb(240,240,240);

--- a/nar_common/static/nar_ui/summary_report/main.js
+++ b/nar_common/static/nar_ui/summary_report/main.js
@@ -302,6 +302,7 @@ $(document).ready(
 						$('#noPesticideData').css('display', 'block');
 						$('#pesticide').css('display', 'none');
 						$('#pesticideComparisonContainer').css('display', 'none');
+						$('#summaryPesticideToggle').css('display', 'none');
 						return;
 					}else{
 						var context = summary[0];
@@ -595,6 +596,13 @@ $(document).ready(
 					
 				});
 			};
+			
+			$('#pesticideToggleButton').on('click', function(){
+				$('#pesticide').toggle();
+				$('#pesticideComparisonContainer').toggle();
+				$('#freqUseGraphContainer').toggle();
+				$('#clearLeft').toggleClass('spotme');
+			});
 			
 			
 			var failedGetDataAvailability = function(data, textStatus,jqXHR) {

--- a/nar_common/static/nar_ui/summary_report/main.js
+++ b/nar_common/static/nar_ui/summary_report/main.js
@@ -597,6 +597,7 @@ $(document).ready(
 				});
 			};
 			
+			//Toggles the pesticide graphs
 			$('#pesticideToggleButton').on('click', function(){
 				$('#pesticide').toggle();
 				$('#pesticideComparisonContainer').toggle();

--- a/nar_common/templates/nar_ui/summary.html
+++ b/nar_common/templates/nar_ui/summary.html
@@ -78,17 +78,13 @@
 		
 		<a href="{% url 'site' %}"><div class="col-lg-1 back_to_site">Back to Map</div></a>
 
-
-
+	</div>
+	
+	<div id="summaryPesticideToggle" class="summaryOptionsBar">
+		<button id="pesticideToggleButton">Toggle Pesticide Graphs</button>
 	</div>
 
-
-
-
-
 	<div class="col-lg-12 graphs col-md-12 col-sm-12 col-xs-12">
-	
-		
 	
 		<div class="stream">
 			
@@ -129,7 +125,7 @@
 			<h3>No Pesticide Data Available</h3>
 		</div>
 
-		<div class="col-lg-4 human col-sm-12 col-xs-12">
+		<div id="clearLeft" class="col-lg-4 human col-sm-12 col-xs-12">
 			<div class="human_row">
 				<h4>Comparisons to Human-Health<br/><span id="link-hover-benchmark-human" class="link-popover-anchor">Benchmarks</span></h4>
 			</div>


### PR DESCRIPTION
Button toggles the pesticide graphs and rearranges graphs accordingly.

Toggle button does not appear when there is no pesticide information to create graphs to avoid confusion.