### PR TITLE
non hardcoded labels

### DIFF
--- a/nar_common/static/nar_ui/handlebars/freqUse.handlebars
+++ b/nar_common/static/nar_ui/handlebars/freqUse.handlebars
@@ -4,7 +4,7 @@
 <div id="freqUseLengend">
 	<div class="legendItem">
 		<div class="legendColorSquare" id="brown"></div>
-		2013
+		<span id="currentWaterYear"></span>
 	</div>
 	<div class="legendItem">
 		<div class="legendColorSquare" id="yellow"></div>

--- a/nar_common/static/nar_ui/handlebars/pesticides.handlebars
+++ b/nar_common/static/nar_ui/handlebars/pesticides.handlebars
@@ -1,5 +1,5 @@
 
-<h4>Pesticides - {{ previousWaterYear }}</h4>
+<h4 id="flowChartHeader"></h4>
 
 <div class="pesticideChartSection">
 	{{npestNew}}

--- a/nar_common/static/nar_ui/summary_report/main.js
+++ b/nar_common/static/nar_ui/summary_report/main.js
@@ -312,6 +312,7 @@ $(document).ready(
 							var html = compiledTemplate(context);
 							//Places mustache file in correct location
 							$('#pesticide').html(html);
+							$('#flowChartHeader').text('Pesticides - ' + (CONFIG.currentWaterYear));
 							var aquaticExceedancesString = $('#aquaticExceedances').text();
 							var aquaticExceedances = aquaticExceedancesString.split(",");
 							var humanExceedancesString = $('#humanExceedances').text();
@@ -339,6 +340,7 @@ $(document).ready(
 								             }
 								return items;
 							};
+							
 							
 							//Bar math
 							var barMath = function(bar, className, ugL){
@@ -388,6 +390,7 @@ $(document).ready(
 							var html = compiledTemplate(hbarData);
 							//Places mustache file in correct location
 							$('#freqUseGraphContainer').html(html);
+							$('#currentWaterYear').text((CONFIG.currentWaterYear));
 							
 							barMath('.upperBar', '.previousWaterYear', '.ugL');
 							barMath('.lowerBar', '.oldWaterYear', '.ugL');
@@ -506,8 +509,13 @@ $(document).ready(
 						}
 						
 						//Giving the charts their design
-						var ticks = ['1992-2012 (Annual average)', '2013', '2014'];
+						var ticks = ['1992 - 2012 (Annual average)', '2013 - ' + (CONFIG.currentWaterYear - 1), (CONFIG.currentWaterYear)];
 						$.jqplot(selector, [data.values],  {
+							axesDefaults: {
+								tickOptions:{
+									formatString: '%d'
+								}
+							},
 							axes:{
 								xaxis: getXAxisBounds(),
 								yaxis:{


### PR DESCRIPTION
@cschroed-usgs Talked to Casey and I unhardcoded all the labels that will change based on the CONFIG.currentWaterYear. The only years that won't change is the 1992 - 2012 and the 2013 on the summary pesticide benchmarks graphs, as it will always be 2013 - previous water year.

